### PR TITLE
Fix AVC playback

### DIFF
--- a/pages/options.html
+++ b/pages/options.html
@@ -18,7 +18,7 @@
 	
 			<div>
 				<input type="checkbox" id="AVC" name="AVC">
-				<label for="AVC">Use AVC-High insted of AVC video code</label>
+				<label for="AVC">Use AVC instead of AVC High video codec</label>
 			</div>
 	
 			<div>
@@ -37,12 +37,12 @@
 	
 			<div>
 				<input type="checkbox" id="HA" name="HA">
-				<label for="HA">HE-AAC Audio(5.1)</label>
+				<label for="HA">HE-AAC Audio (5.1)</label>
 			</div>
 
 			<div>
 				<input type="checkbox" id="AVCH" name="AVCH">
-				<label for="AVCH">Use AVC-High insted of VP9 video code</label>
+				<label for="AVCH">Use AVC High instead of VP9 video codec</label>
 			</div>
 		</fieldset>
 	</form>	


### PR DESCRIPTION
By reverting the behaviour used in v1.41 of the extension, I fixed AVC playback.

AVC High is the default, and you need to tick to enable AVC like previous behaviour.

Fixes https://github.com/lkmvip/netflix-4K-DDplus/issues/41