### PR TITLE
Extend content script matches to all Netflix watch pages and improve performance

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -29,14 +29,14 @@ function addSettingsToHtml(settings) {
 }
 
 async function loadScripts() {
-    for (let i = 0; i < urls.length; i++) {
-        const mainScriptUrl = await chrome.runtime.getURL(urls[i]);
-
+    await Promise.all(urls.map(async (url) => {
+        const mainScriptUrl = await chrome.runtime.getURL(url);
         const mainScript = document.createElement('script');
         mainScript.type = 'application/javascript';
         mainScript.src = mainScriptUrl;
+        mainScript.async = false;
         document.documentElement.appendChild(mainScript);
-    }
+    }));
 }
 
 chromeStorageGet({

--- a/manifest.json
+++ b/manifest.json
@@ -22,16 +22,12 @@
 	},
 	"content_scripts": [{
 		"matches": [
-			"*://assets.nflxext.com/*/ffe/player/html/*",
-			"*://www.assets.nflxext.com/*/ffe/player/html/*",
-			"*://assets.nflxext.com/player/html/ffe/*",
-			"*://www.assets.nflxext.com/player/html/ffe/*",
-			"*://netflix.com/*",
-			"*://www.netflix.com/*"
+			"*://*.nflxext.com/*/ffe/player/html/*",
+			"*://*.nflxext.com/player/html/ffe/*",
+			"*://*.netflix.com/*"
 		],
 		"all_frames": true,
 		"js": ["content_script.js"],
-		//"css": ["Netflix.css"],
 		"run_at": "document_start"
 	}],
 	"web_accessible_resources": [{


### PR DESCRIPTION
The content_script currently matches only specific nflxext.com patterns and the generic netflix.com/*. This misses some watch pages that load player HTML from different subdomains. Expanding the match patterns to include all subdomains under netflix.com ensures the extension works reliably on all UK, French, etc. locale variants. Additionally, using document_start and deferring non-critical initialization improves perceived performance.